### PR TITLE
Updated readme for the benefit of Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 python-echoprint
 ================
 
-A Python library for Echonest's [Echoprint](http://echoprint.me/) music identification service. 
+A Python library for Echonest's [Echoprint](http://echoprint.me/) music identification service.
 
 Unlike the [official library](http://code.google.com/p/pyechonest/), it does not need to save anything to disk -- a list of samples can be passed directly to the library.
 
@@ -11,6 +11,15 @@ Building
 First, you need to install the build dependencies. On Ubuntu/Debian, run:
 
     $ sudo apt-get install python-dev libboost-dev libtag1-dev ffmpeg
+
+Ubuntu 14.04 users should note that `ffmpeg` is not available in the official
+Ubuntu repositories. It can be retrieved from [Jon Severinsson's FFmpeg PPA](https://launchpad.net/~jon-severinsson/+archive/ubuntu/ffmpeg)
+
+    sudo apt-add-repository ppa:jon-severinsson/ffmpeg
+    sudo apt-get update
+    sudo apt-get install ffmpeg
+
+Ubuntu users who cannot install `ffmpeg` or are interested in more information on the subject should consult this [Askubuntu answer](http://askubuntu.com/a/432585/103738).
 
 On OS X, you need to install [Homebrew](http://mxcl.github.com/homebrew/), and
 run:
@@ -42,5 +51,3 @@ Test suite
 
     $ pip install nose
     $ nosetests
-
-


### PR DESCRIPTION
The readme assumes that it is possible to get
ffmpeg from the official Ubuntu repos. It is not
and according to http://askubuntu.com/a/432585/103738,
it will only be back with Ubuntu 15.04 Vivid Vervet. I've added an
alternate source in the meantime.
